### PR TITLE
Made build more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ libbfd/libbfd.idl: libbfd/bfdarch.idl
 
 libbfd/bfdarch.idl:
 	echo '#include "bfd.h"' \
-		| $(CC) -E -xc - \
+		| $(CC) -DPACKAGE -E -xc - \
 		| awk 'BEGIN { go=0; } /^enum bfd_architecture$$/ { go=1; } \
 		       go && $$0 != "" { print; } \
 		       /machine_t/ { print; } \

--- a/buildtools/depcheck.sh
+++ b/buildtools/depcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###############################################################################
 # OCaml dependency checker                                                    #
@@ -73,7 +73,7 @@ EOF
     exit 1
   fi
 
-  gcc -Wall -Werror $tmpfile -o $tmpdir/a.out
+  gcc -DPACKAGE -Wall -Werror $tmpfile -o $tmpdir/a.out
   success=$?
   rm -rf $tmpdir
 

--- a/libbfd/bfdwrap_helper.c
+++ b/libbfd/bfdwrap_helper.c
@@ -17,6 +17,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #include "bfdwrap.h"
 
+#define PACKAGE
 #include <bfd.h>
 #include <dis-asm.h>
 #include <stdio.h>

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -50,6 +50,9 @@ let camlidl = S([A"camlidl"])
 (* ocaml path *)
 let ocamlpath = List.hd & split_nl & run_and_read "ocamlfind printconf path"
 
+(* camlidl path *)
+let camlidl_path = List.hd & split_nl & run_and_read "ocamlfind query camlidl"
+
 let _ = dispatch begin function
   | Before_options ->
 
@@ -109,7 +112,7 @@ let _ = dispatch begin function
 
       (* c stub generated from camlidl *)
       flag ["c"; "compile"; "stubs"]
-        (S[A"-ccopt";A("-I"^ocamlpath^"/camlidl");]);
+        (S[A"-ccopt";A("-I"^camlidl_path);]);
 
       (* camlidl needs to consider bfdarch *)
       flag ["camlidl"; "compile"]
@@ -136,7 +139,7 @@ let _ = dispatch begin function
           A"-cclib"; A"-lbfdarch_stubs";
           A"-cclib"; A"-lbfd";
           A"-cclib"; A"-lopcodes";
-          A"-cclib"; A("-L"^ocamlpath^"/camlidl");
+          A"-cclib"; A("-L"^camlidl_path);
           A"-cclib"; A"-lcamlidl";
         ]);
 


### PR DESCRIPTION
- Switched references to ocamlpath/camlidl to actual camlidl path
- Define PACKAGE before including bfd.h to deal with modern bfd assumptions about autoconf use
- Use $(SHELL) to invoke depcheck.sh for greater compatibility.
